### PR TITLE
Change dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.js]
+quote_type = single

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - stable
   - "6"
-  - "4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
+# Changelog
+
+## 1.0.1 - 11.03.2019
+
+* Change dependency version of `typographic-currency-db` to `^1.0.1`
+
 ## 1.0.0 - 19.05.2017
+
 * Update dependencies (PostCSS 6)
 * Support node >= 4
 * Add eslint config to package.json
 * Delte `gulp lint` task
 
 ## 0.1
+
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PostCSS Currency [![Build Status][ci-img]][ci]
+# PostCSS Currency [![Build Status][ci-img]][ci] [![NPM version][npm-image]][npm-url]
 
 [PostCSS] plugin replaces the name of currency with symbols.
 
@@ -28,4 +28,7 @@ See [PostCSS] docs for examples for your environment.
 
 ## License
 
-MIT © [talgautb](http://gtalk.kz)
+MIT © [talgautb](https://gtalk.kz)
+
+[npm-url]: https://npmjs.org/package/postcss-currency
+[npm-image]: https://img.shields.io/npm/v/postcss-currency.svg?style=flat-square

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,15 @@
-var gulp = require('gulp');
+let gulp = require('gulp');
+let mocha = require('gulp-mocha');
 
-var files = ['index.js', 'test/*.js', 'gulpfile.js'];
+let files = ['index.js', 'test/*.js', 'gulpfile.js'];
 
-gulp.task('test', function () {
-    var mocha = require('gulp-mocha');
-    return gulp.src('test/*.js', { read: false })
-        .pipe(mocha());
-});
+function test() {
+  return gulp.src('test/*.js', { read: false }).pipe(mocha());
+}
 
-gulp.task('default', ['test']);
+function watch() {
+  gulp.watch(files, test);
+}
 
-gulp.task('watch', function () {
-    gulp.watch(files, ['test']);
-});
+exports.watch = watch;
+exports.default = test;

--- a/index.js
+++ b/index.js
@@ -2,24 +2,18 @@ var postcss = require('postcss');
 var currencyDB = require('typographic-currency-db');
 
 module.exports = postcss.plugin('postcss-currency', function () {
+  return function (css) {
+    css.walkDecls('content', function (decl) {
+      var quote = decl.value.match(/'|"/);
+      quote = quote ? quote[0] : '';
 
-    return function (css) {
+      for (var key in currencyDB) {
+        var value = decl.value.replace(/['"]+/g, '').toUpperCase();
 
-        css.walkDecls('content', function (decl) {
-
-            var quote = decl.value.match(/'|"/);
-            quote = quote ? quote[0] : '';
-
-            for (var key in currencyDB) {
-
-                var value = decl.value.replace(/['"]+/g, '').toUpperCase();
-
-                if (value === key) {
-                    decl.value = quote + currencyDB[key] + quote;
-                }
-            }
-
-        });
-
-    };
+        if (value === key) {
+          decl.value = quote + currencyDB[key] + quote;
+        }
+      }
+    });
+  };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,18 +59,23 @@
         "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        }
       }
     },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
-    },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-jsx": {
@@ -116,7 +121,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -536,12 +540,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -757,7 +760,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -765,19 +767,13 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
-    },
-    "colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1124,13 +1120,12 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
-      "integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
+      "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1143,7 +1138,7 @@
         "enquirer": "^2.3.5",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^1.3.0",
+        "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.0",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
@@ -1170,12 +1165,23 @@
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        }
       }
     },
     "eslint-config-postcss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-postcss/-/eslint-config-postcss-4.0.0.tgz",
-      "integrity": "sha512-vOvKpJ6xnuveq6wCDzyg/M6ZguqpxILdLmi6jLuJy92aN0bwygkGkUGc/m3TP0kvGo9BofbrhtX/DFPZ9kTp4Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-postcss/-/eslint-config-postcss-2.0.2.tgz",
+      "integrity": "sha1-yuHGCTzteFCJSluF++HR4jK3Kvs=",
       "dev": true
     },
     "eslint-scope": {
@@ -1195,12 +1201,20 @@
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "espree": {
@@ -1212,6 +1226,14 @@
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -1819,15 +1841,6 @@
         }
       }
     },
-    "globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^0.8.1"
-      }
-    },
     "glogg": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -1960,8 +1973,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -2311,7 +2323,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -2426,25 +2439,6 @@
         "object.map": "^1.0.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
-      }
-    },
-    "line-column": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
-      "integrity": "sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=",
-      "requires": {
-        "isarray": "^1.0.0",
-        "isobject": "^2.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
       }
     },
     "load-json-file": {
@@ -2888,11 +2882,6 @@
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "dev": true,
       "optional": true
-    },
-    "nanoid": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3372,14 +3361,43 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.1.tgz",
-      "integrity": "sha512-9DGLSsjooH3kSNjTZUOt2eIj2ZTW0VI2PZ/3My+8TC7KIbH2OKwUlISfDsf63EP4aiRUt3XkEWMWvyJHvJelEg==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "requires": {
-        "colorette": "^1.2.1",
-        "line-column": "^1.0.2",
-        "nanoid": "^3.1.12",
-        "source-map": "^0.6.1"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "prelude-ls": {
@@ -4250,9 +4268,9 @@
       "dev": true
     },
     "typographic-currency-db": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typographic-currency-db/-/typographic-currency-db-1.0.1.tgz",
-      "integrity": "sha512-uiMbgtTL2fCkyie7bg4ymcVZRRiI3rk8GEUweTydXPnvGcZtamdU+0zgE5RJhgD1rCWmDwTWD3KyKE2U/i6dyw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typographic-currency-db/-/typographic-currency-db-1.1.0.tgz",
+      "integrity": "sha512-5jZUXM87e5iF/9+cWU4jSPmIEvwSYtDW0VY2jN7Ia3aRl5oEPs3seVAmLqb9PSvBaaZ+5ZpJSZkmabicb+1t4A=="
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   },
   "homepage": "https://github.com/talgautb/postcss-currency",
   "dependencies": {
-    "postcss": "^8.1.1",
-    "typographic-currency-db": "^1.0.1"
+    "postcss": "^7.0.35",
+    "typographic-currency-db": "^1.1.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^7.10.0",
-    "eslint-config-postcss": "^4.0.0",
+    "eslint": "^7.11.0",
+    "eslint-config-postcss": "^2.0.2",
     "gulp": "^4.0.2",
     "gulp-mocha": "^7.0.2"
   },
@@ -34,6 +34,27 @@
     "test": "gulp && eslint *.js"
   },
   "eslintConfig": {
-    "extends": "eslint-config-postcss/es5"
+    "env": {
+      "es6": true,
+      "mocha": true,
+      "node": true
+    },
+    "extends": [
+      "eslint:recommended",
+      "eslint-config-postcss/es5"
+    ],
+    "rules": {
+      "comma-dangle": 0,
+      "function-paren-newline": 0,
+      "indent": [
+        "error",
+        2
+      ],
+      "quotes": [
+        "warn",
+        "single"
+      ],
+      "semi": 0
+    }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,42 +1,41 @@
-var postcss = require('postcss');
-var expect  = require('chai').expect;
+let postcss = require('postcss');
+let expect = require('chai').expect;
 
-var plugin = require('../');
+let plugin = require('../');
 
-var test = function (input, output, opts) {
-    return postcss([ plugin(opts) ]).process(input).then(function (result) {
-        expect(result.css).toEqual(output);
-        expect(result.warnings()).toHaveLength(0);
+let test = function (input, output, opts) {
+  return postcss([plugin(opts)])
+    .process(input, { from: undefined })
+    .then((result) => {
+      expect(result.css).to.equal(output);
+      expect(result.warnings()).to.have.length(0);
     });
 };
 
-describe('postcss-currency', function () {
+describe('postcss-currency', () => {
+  it('simple test', () => {
+    return test("a:after{content: 'kzt'}", "a:after{content: '₸'}", {});
+  });
 
-    it('simple test', function () {
-        test('a:after{content: \'kzt\'}', 'a:after{content: \'₸\'}', { } );
-    });
+  it('check uppercase', () => {
+    return test('a:after{ content: "JPy"}', 'a:after{ content: "¥"}', {});
+  });
 
-    it('check uppercase', function () {
-        test('a:after{ content: "JPy"}', 'a:after{ content: "¥"}', { } );
-    });
-
-    it('another content', function () {
-        test('a:before{ content: euri}', 'a:before{ content: euri}', { } );
-    });
-
+  it('another content', () => {
+    return test('a:before{ content: euri}', 'a:before{ content: euri}', {});
+  });
 });
 
-describe('check quotes', function () {
+describe('check quotes', () => {
+  it('check double quotes', () => {
+    return test("a:after{content: 'usd'}", "a:after{content: '$'}", {});
+  });
 
-    it('check dowble quotes', function () {
-        test('a:after{content: \'usd\'}', 'a:after{content: \'$\'}', { } );
-    });
+  it('check double quotes', () => {
+    return test('a:after{ content: "gbp"}', 'a:after{ content: "£"}', {});
+  });
 
-    it('check dowble quotes', function () {
-        test('a:after{ content: "gbp"}', 'a:after{ content: "£"}', { } );
-    });
-
-    it('witout quotes', function () {
-        test('a:before{ content: cny}', 'a:before{ content: ¥}', { } );
-    });
+  it('without quotes', () => {
+    return test('a:before{ content: cny}', 'a:before{ content: ¥}', {});
+  });
 });


### PR DESCRIPTION
@talgautb Hi, this is the master (aka v1) with some reverted and updated some dependencies.

This is the changelog:

* Added simple eslint config to match the code style
* Added NPM badge
* Changed `typographic-currency-db` dependency version to `v1.1.0` with changed import
* Changed `eslint-config-postcss` dependency version back to the `v2.0,2`, check note below
* Changed `postcss` dependency version to **7**. Note: PostCSS 7 dropped Node.js 4 and 9 support since it doesn’t have security updates anymore. In general, it's an almost non-breaking change except that node 4 drop. If you want we can add this change to the readme.
* Changed readme to have https URL
* Removed Node.js 4 support from Travis

Note about `eslint-config-postcss` change, new versions will pull more than 12 other dev-dependencies and other nonsignificant config changes, so I would suggest to remove it in the next PR, tell me if you would like to keep it.

Next one with postcss v8 updated I'll open asap as this one would pass your review and be merged and released.

That PR closes Issue #5 and PR #6.

And as a part of the Hacktoberfest month, I would appreciate and like to ask you to add all the necessary labels(tags), please.
It is hacktoberfest topic to the repository, and hacktoberfest-accepted if PR was accepted.

Screenshot of tests:
![Screenshot 2020-10-09 195525](https://user-images.githubusercontent.com/139212/95640617-91deac80-0a6b-11eb-93af-8acebc964b07.png)
